### PR TITLE
Fix default trending genre

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -3,7 +3,7 @@ import Results from "@/components/Results"
 const API_KEY = process.env.API_KEY
 
 export default async function Home({searchParams}) {
-  const genre = searchParams.genre || 'fethcTrending'
+  const genre = searchParams.genre || 'fetchTrending'
   const res = await fetch(
     `https://api.themoviedb.org/3${
       genre === 'fetchTopRated' ? '/movie/top_rated' : '/trending/all/week'


### PR DESCRIPTION
## Summary
- fix typo in home page default genre so trending movies load correctly

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f1ebdc64832c8f25f8e636ceb597