### PR TITLE
Add SearchBox tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "next": "14.2.2",

--- a/src/components/__tests__/SearchBox.test.jsx
+++ b/src/components/__tests__/SearchBox.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchBox from '../SearchBox';
+import mockRouter from 'next-router-mock';
+
+jest.mock('next/navigation', () => ({
+  useRouter() {
+    return mockRouter;
+  },
+}));
+
+describe('SearchBox', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('submits a search term and navigates', () => {
+    render(<SearchBox />);
+
+    const input = screen.getByPlaceholderText(/search keywords/i);
+    fireEvent.change(input, { target: { value: 'batman' } });
+
+    const form = input.closest('form');
+    fireEvent.submit(form);
+
+    expect(mockRouter.push).toHaveBeenCalledWith('/search/batman');
+  });
+
+  it('does not submit when search is empty', () => {
+    render(<SearchBox />);
+    const button = screen.getByRole('button', { name: /search/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add SearchBox RTL tests using next-router-mock
- expose `npm test` script in package.json

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f1f66a94832ca4976beafb7f4243