### PR TITLE
Fix missing alt attributes in Image components

### DIFF
--- a/src/app/movie/[id]/page.jsx
+++ b/src/app/movie/[id]/page.jsx
@@ -14,6 +14,7 @@ export default async function MoviePage({params}) {
                 width={500}
                 height={300}
                 className='rounded-lg'
+                alt={movie.title || movie.name || 'Movie poster'}
             >
             </Image>
             <div className='p-4'>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -9,12 +9,12 @@ export default function Card( {result}) {
     sm:shadow-md rounded-lg sm:border sm:border-slate-400 
     sm:m-2 transition-shadow duration-200'>
         <Link href={`/movie/${result.id}`}>
-            <Image 
-                src={`https://image.tmdb.org/t/p/original/${result.poster_path}`} 
+            <Image
+                src={`https://image.tmdb.org/t/p/original/${result.poster_path}`}
                 width={500}
                 height={200}
                 className='sm:rounded-t-lg group-hover:opacity-80 transition duration-300 ease-in-out cursor-pointer'
-                alt={result.title}            
+                alt={result.title || result.original_name || result.name || 'Movie image'}
             ></Image>
             <div className='p-2'>
                 <p className='line-clamp-2 text-md'>{result.overview}</p>


### PR DESCRIPTION
## Summary
- add alt text in `MoviePage` image
- improve alt text fallback in `Card`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f153e104832cba16fe3312937deb